### PR TITLE
Allow traversing by embedded fields

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -148,6 +148,15 @@ func GetFieldByTag(ival interface{}, tagName string, fieldNames []string) (inter
 	for i := 0; i < valType.NumField(); i++ {
 		tagValue := valType.Field(i).Tag.Get(tagName)
 
+		// If it's an embedded field, traverse it.
+		if tagValue == "" && valType.Field(i).Anonymous {
+			value := val.Field(i).Interface()
+			val, err := GetFieldByTag(value, tagName, fieldNames)
+			if err == nil {
+				return val, nil
+			}
+		}
+
 		parts := strings.Split(tagValue, ",")
 		if parts[0] == fieldName {
 			value := val.Field(i).Interface()


### PR DESCRIPTION
We have some resources with embedded fields: [example](https://github.com/gravitational/teleport/blob/master/api/types/types.proto#L2763), we need to be able to traverse these embedded fields