### PR TITLE
Merge upstream changes from vulcand/predicate

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.16, 1.17, 1.x ]
+        go-version: [ 1.18, 1.19, 1.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     name: Main Process
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: 1.17
-      GOLANGCI_LINT_VERSION: v1.43.0
+      GO_VERSION: 1.18
+      GOLANGCI_LINT_VERSION: v1.49.0
       CGO_ENABLED: 0
 
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   skip-files: []
 
 linters-settings:
@@ -19,10 +19,17 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - golint # deprecated
-    - maligned # deprecated
-    - interfacer # deprecated
     - scopelint # deprecated
+    - interfacer # deprecated
+    - maligned # deprecated
+    - golint # deprecated
+    - exhaustivestruct # deprecated
+    - scopelint # deprecated
+    - varcheck # deprecated
+    - structcheck # deprecated
+    - nosnakecase # deprecated
+    - deadcode # deprecated
+    - ifshort # deprecated
     - sqlclosecheck # not relevant (SQL)
     - rowserrcheck # not relevant (SQL)
     - cyclop # duplicate of gocyclo
@@ -34,7 +41,7 @@ linters:
     - goerr113
     - wrapcheck
     - exhaustive
-    - exhaustivestruct
+    - exhaustruct
     - testpackage
     - tparallel
     - paralleltest
@@ -44,6 +51,7 @@ linters:
     - varnamelen
     - nilnil
     - ireturn
+    - nonamedreturns
 
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,3 +65,4 @@ issues:
       linters:
         - funlen
         - goconst
+        - tagliatelle

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ func main(){
     })
 
     pr, err := p.Parse("DivisibleBy(2) && DivisibleBy(3)")
-    if err == nil {
-        log.Fatalf("Error: %v", err)
-    }
+    if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
 
-    pr.(numberPredicate)(2) // false
-    pr.(numberPredicate)(3) // false
-    pr.(numberPredicate)(6) // true
+	fmt.Println(pr.(numberPredicate)(2)) // false
+	fmt.Println(pr.(numberPredicate)(3)) // false
+	fmt.Println(pr.(numberPredicate)(6)) // true
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.16
 require (
 	github.com/gravitational/trace v1.1.16-0.20220114165159-14a9a7dd6aaf
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,22 @@
 module github.com/vulcand/predicate
 
-go 1.16
+go 1.17
 
+// we use a pseudo version for github.com/gravitational/trace
+// because the a bump of GRPC has been made in this package and can influence predicate clients.
+// https://github.com/gravitational/trace/compare/14a9a7dd6aaf...v1.1.17
 require (
 	github.com/gravitational/trace v1.1.16-0.20220114165159-14a9a7dd6aaf
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
+	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102 // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,9 +49,8 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,12 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
@@ -49,8 +51,9 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -67,7 +70,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/methods_test.go
+++ b/methods_test.go
@@ -14,7 +14,7 @@ func TestMethods(t *testing.T) {
 		Functions: map[string]interface{}{
 			"set":    newSet,
 			"list":   newList,
-			"append": fn_append,
+			"append": customAppend,
 		},
 		Methods: map[string]interface{}{
 			"add":      set.add,
@@ -102,8 +102,6 @@ func TestMethods(t *testing.T) {
 			require.Equal(t, tc.expectOutput, output)
 		})
 	}
-
-	return
 }
 
 // set is an example set type used to demonstrate use of methods.
@@ -157,6 +155,6 @@ type container interface {
 	contains(str string) bool
 }
 
-func fn_append(l list, str string) list {
+func customAppend(l list, str string) list {
 	return append(append([]string{}, l...), str)
 }

--- a/predicate.go
+++ b/predicate.go
@@ -21,42 +21,42 @@ various predicates for configuration, e.g. Latency() > 40 || ErrorRate() > 0.5.
 
 Here's an example of fully functional predicate language to deal with division remainders:
 
-    // takes number and returns true or false
-    type numberPredicate func(v int) bool
+	    // takes number and returns true or false
+	    type numberPredicate func(v int) bool
 
-    // Converts one number to another
-    type numberMapper func(v int) int
+	    // Converts one number to another
+	    type numberMapper func(v int) int
 
-    // Function that creates predicate to test if the remainder is 0
-    func divisibleBy(divisor int) numberPredicate {
-	    return func(v int) bool {
-		    return v%divisor == 0
-        }
-    }
+	    // Function that creates predicate to test if the remainder is 0
+	    func divisibleBy(divisor int) numberPredicate {
+		    return func(v int) bool {
+			    return v%divisor == 0
+	        }
+	    }
 
-    // Function - logical operator AND that combines predicates
-    func numberAND(a, b numberPredicate) numberPredicate {
-        return func(v int) bool {
-            return a(v) && b(v)
-        }
-    }
+	    // Function - logical operator AND that combines predicates
+	    func numberAND(a, b numberPredicate) numberPredicate {
+	        return func(v int) bool {
+	            return a(v) && b(v)
+	        }
+	    }
 
-    p, err := NewParser(Def{
-		Operators: Operators{
-			AND: numberAND,
-		},
-		Functions: map[string]interface{}{
-			"DivisibleBy": divisibleBy,
-		},
-	})
+	    p, err := NewParser(Def{
+			Operators: Operators{
+				AND: numberAND,
+			},
+			Functions: map[string]interface{}{
+				"DivisibleBy": divisibleBy,
+			},
+		})
 
-	pr, err := p.Parse("DivisibleBy(2) && DivisibleBy(3)")
-    if err == nil {
-        fmt.Fatalf("Error: %v", err)
-    }
-    pr.(numberPredicate)(2) // false
-    pr.(numberPredicate)(3) // false
-    pr.(numberPredicate)(6) // true
+		pr, err := p.Parse("DivisibleBy(2) && DivisibleBy(3)")
+	    if err == nil {
+	        fmt.Fatalf("Error: %v", err)
+	    }
+	    pr.(numberPredicate)(2) // false
+	    pr.(numberPredicate)(3) // false
+	    pr.(numberPredicate)(6) // true
 */
 package predicate
 

--- a/predicate.go
+++ b/predicate.go
@@ -68,8 +68,8 @@ type Def struct {
 	Functions map[string]interface{}
 	// Methods is a map of method names to their implementation.
 	Methods map[string]interface{}
-	// GetIdentifier returns value of any identifier passed in
-	// in the form []string{"id", "field", "subfield"}
+	// GetIdentifier returns value of any identifier passed in the form
+	// []string{"id", "field", "subfield"}
 	GetIdentifier GetIdentifierFn
 	// GetProperty returns property from a map
 	GetProperty GetPropertyFn


### PR DESCRIPTION
This PR merges the new upstream changes from https://github.com/vulcand/predicate into our fork. There are no code changes, just go version, ci, and comments.

I'm planning to publish a new release of gravitational/predicate, so it seems like a good time to merge upstream changes.