### PR TITLE
gha: drop usage of `actions/cache@v2`

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -25,19 +25,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # https://github.com/marketplace/actions/cache
-      - name: Cache Go modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/go/pkg/mod              # Module download cache
-            ~/.cache/go-build         # Build cache (Linux)
-            ~/Library/Caches/go-build # Build cache (Mac)
-            '%LocalAppData%\go-build' # Build cache (Windows)
-          key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.go-version }}-go-
-
       - name: Test
         run: go test -v -cover ./...
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # https://github.com/marketplace/actions/cache
-      - name: Cache Go modules
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Check and get dependencies
         run: |
           go mod tidy


### PR DESCRIPTION
`actions/cache@v2` support ended and users are forced to upgrade to `v3/v4`. For this particular example, we do not have any good usage for cache so it's just better to drop it entirely.