### PR TITLE
deref multi-levels if interface is satisfied by pointer

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -166,7 +166,10 @@ func getFieldByTag(val reflect.Value, tagName string, fieldNames []string) (inte
 		return nil, trace.BadParameter("missing field names")
 	}
 
-	if val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr {
+	for val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil, &notFoundError{fieldNames: fieldNames}
+		}
 		val = val.Elem()
 	}
 


### PR DESCRIPTION
If the underlying type is an interface satisfied by a pointer, we need to deref it multiple times until we reach to the struct value.

This PR does that by calling `val.Elem()` multiple times while `val.Kind()` is an interface or pointer.