### PR TITLE
Allow passing an ast.Expr to a predicateParser

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -13,6 +13,10 @@ import (
 )
 
 func NewParser(d Def) (Parser, error) {
+	return NewASTParser(d)
+}
+
+func NewASTParser(d Def) (ASTParser, error) {
 	return &predicateParser{d: d}, nil
 }
 
@@ -26,6 +30,10 @@ func (p *predicateParser) Parse(in string) (any, error) {
 		return nil, err
 	}
 
+	return p.ParseAST(expr)
+}
+
+func (p *predicateParser) ParseAST(expr ast.Expr) (any, error) {
 	return p.parse(expr)
 }
 

--- a/predicate.go
+++ b/predicate.go
@@ -60,6 +60,8 @@ Here's an example of fully functional predicate language to deal with division r
 */
 package predicate
 
+import "go/ast"
+
 // Def defines parser context including supported operators, functions, methods,
 // identifiers, and property accessors.
 type Def struct {
@@ -102,4 +104,11 @@ type Operators struct {
 // Parser takes the string with expression and calls the operators and functions.
 type Parser interface {
 	Parse(string) (any, error)
+}
+
+// ASTParser is just like [Parser] but it lets the caller pass an [ast.Expr]
+// object rather than an expression in string form.
+type ASTParser interface {
+	Parser
+	ParseAST(ast.Expr) (any, error)
 }


### PR DESCRIPTION
With this change the caller can pass an `ast.Expr` to the parser rather than passing a string which will get parsed by `go/parser.ParseExpr`. This can be helpful if the caller wants to either generate some synthetic AST or wants to parse the expression by hand to then manipulate the AST to apply transformations (at least, purely syntactic ones).